### PR TITLE
 Bitbucket social icon support

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -307,6 +307,7 @@ if ( ! function_exists( 'ct_author_social_array' ) ) {
 			'deviantart'    => 'author_deviantart_profile',
 			'digg'          => 'author_digg_profile',
 			'github'        => 'author_github_profile',
+			'bitbucket'     => 'author_bitbucket_profile',
 			'hacker-news'   => 'author_hacker-news_profile',
 			'snapchat'      => 'author_snapchat_profile',
 			'bandcamp'      => 'author_bandcamp_profile',
@@ -358,6 +359,7 @@ if ( ! function_exists( 'ct_author_social_icons_output' ) ) {
 			'steam',
 			'xing',
 			'github',
+			'bitbucket',
 			'google-plus',
 			'behance',
 			'facebook'


### PR DESCRIPTION
Hello there, I'm not sure if you accept patches/merges but I wanted to tweak your theme a little bit to add support for my bitbucket account _(ironic doing the pull request here, I know)_ and so here it is.

This would ultimately help me to avoid patching my own version and take advantage of the WP autoupdate.

Thanks in advance!